### PR TITLE
Checker daemon launch script that sets the quit_when_done option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Perl-based scripts for ArrayExpress and Expression Atlas curation
 
 ## Purpose
 
-The scripts are used by ArrayExpress and Expression Atlas curators for validating and processing experiments and array designs in MAGE-TAB format. 
+The scripts are used by ArrayExpress and Expression Atlas curators for validating and processing experiments and array designs in MAGE-TAB format.
 
 
 ## Installation notes
-Using the scripts relies on the [perl-atlas-modules](https://github.com/ebi-gene-expression-group/perl-atlas-modules) being installed. This can most easily be achieved using the [bioconda package](https://anaconda.org/bioconda/perl-atlas-modules). 
+Using the scripts relies on the [perl-atlas-modules](https://github.com/ebi-gene-expression-group/perl-atlas-modules) being installed. This can most easily be achieved using the [bioconda package](https://anaconda.org/bioconda/perl-atlas-modules).
 
 Some parameters in the configuration file [ArrayExpressSiteConfig.yml](https://github.com/ebi-gene-expression-group/perl-atlas-modules/blob/develop/supporting_files/ArrayExpressSiteConfig.yml) need to be modified after installation in order to run the validation scripts:
 
@@ -52,13 +52,19 @@ launch_tracking_daemons.pl -k
 Kill all running daemons
 
 ```
-launch_tracking_daemons.pl -p MAGE-TAB 
+launch_tracking_daemons.pl -p MAGE-TAB
 ```
 Start up a MAGE-TAB checker daemon that checks MAGE-TAB submissions marked as "Waiting" in the submissions tracking database
+
+```
+single_use_tracking_daemon.pl -p MAGE-TAB -s
+```
+Run the MAGE-TAB checker once to process all eligible experiments and then quit (no tracking of instance in the DB)
+
 
 ### Manually insert an array design
 
 ```
 magetab_insert_array.pl -f adf_file_name.txt -l username
 ```
-This inserts a new array design file (ADF) into the submissions tracking DB and assigns it the next available accession number and triggers the ADF validation 
+This inserts a new array design file (ADF) into the submissions tracking DB and assigns it the next available accession number and triggers the ADF validation

--- a/single_use_tracking_daemon.pl
+++ b/single_use_tracking_daemon.pl
@@ -211,18 +211,6 @@ foreach my $pipeline (@pipeline_objects) {
 			my @pids = <$pid_fh>;
 			push( @child_pids, $pids[0] );
 
-			# Store pid in subs tracking
-			# ArrayExpress::AutoSubmission::DB::DaemonInstance->insert(
-			# 	{
-			# 		pipeline_id => $pipeline->id,
-			# 		daemon_type => $type,
-			# 		pid         => $pids[0],
-			# 		start_time  => date_now(),
-			# 		running     => 1,
-			# 		user        => getlogin,
-			# 	}
-			# );
-
 			unlink $pidfile;
 		}
 		else {
@@ -247,18 +235,6 @@ while (1) {
 		chomp $pid;
 		next PID if $dead{$pid};
 		$log->info("$pid is dead");
-
-		# Record that the process has died
-
-		# my @results = ArrayExpress::AutoSubmission::DB::DaemonInstance->search(
-		# 	running => 1,
-		# 	pid     => $pid,
-		# );
-		#
-		# if ( my $di = $results[0] ) {
-		# 	$di->set( running => 0, end_time => date_now() );
-		# 	$di->update;
-		# }
 
 		$dead{$pid} = 1;
 	}

--- a/single_use_tracking_daemon.pl
+++ b/single_use_tracking_daemon.pl
@@ -1,0 +1,272 @@
+#!/usr/bin/env perl
+
+=head1 NAME
+
+launch_tracking_daemons.pl
+
+=head1 DESCRIPTION
+
+Script to launch a daemon with stop parameter and no writing to DB
+
+=head1 SYNOPSIS
+
+To start a specific daemons:
+launch_tracking_daemons.pl -p MAGE-TAB -s
+
+=head1 AUTHOR
+
+Originally written by Anna Farne and updated by Emma Hastings (2014)
+modified by Anja Fullgrabe (2021)
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright [2011] EMBL - European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific
+language governing permissions and limitations under the
+License.
+
+=cut
+
+use strict;
+use warnings;
+
+use Data::Dumper;
+use Getopt::Long;
+use English;
+use POSIX ":sys_wait_h";
+use File::Temp qw(tempfile);
+use Log::Dispatch;
+
+use EBI::FGPT::Config qw($CONFIG);
+use EBI::FGPT::Common qw(date_now);
+
+use ArrayExpress::AutoSubmission::DB::Pipeline;
+use ArrayExpress::AutoSubmission::DB::DaemonInstance;
+
+$| = 1;
+
+my $log = Log::Dispatch->new(
+	outputs => [
+		[
+			'Screen',
+			min_level => 'debug',
+			newline   => 1
+		]
+	],
+);
+
+my ( @pipelines, $help, $stop );
+
+GetOptions(
+	"p|pipeline=s" => \@pipelines,
+	"h|help"       => \$help,
+	"s|stop"       => \$stop,
+);
+
+my $usage = <<END;
+    Usage:
+
+      To start specific daemon and stop it after use:
+      launch_tracking_daemons.pl -p MAGE-TAB -s
+
+END
+
+if ($help) {
+	print $usage;
+	exit;
+}
+
+
+# Get the pipeline objects from names specified by user
+my @pipeline_objects;
+if (@pipelines) {
+	foreach my $pl (@pipelines) {
+		my @results =
+		  ArrayExpress::AutoSubmission::DB::Pipeline->search(
+			submission_type => $pl );
+
+		# If we dont recognise pipeline requested we die
+		unless (@results) {
+			$log->log_and_die(
+				level   => 'alert',
+				message => "Could not find pipeline with name $pl\n"
+			);
+		}
+		push @pipeline_objects, $results[0];
+	}
+}
+else {
+
+	# Or get list of defaults from subs tracking
+	my $result = ArrayExpress::AutoSubmission::DB::Pipeline->retrieve_all;
+	while ( my $pipeline = $result->next ) {
+		if ( $pipeline->instances_to_start ) {
+			my $num = $pipeline->instances_to_start - 1;
+			for ( 0 .. $num ) {
+				push @pipeline_objects, $pipeline;
+			}
+		}
+	}
+}
+
+my @child_pids;
+foreach my $pipeline (@pipeline_objects) {
+
+	# Get pipeline parameters from subs tracking
+
+	# Submission type i.e. MAGE-TAB and GEO
+	my $submis_type = $pipeline->submission_type;
+
+	#  rpetry: We no longer run exporter_deamon  TYPE: foreach my $daemon ( "checker_daemon", "exporter_daemon" ) {
+	foreach my $daemon ( "checker_daemon" ) {
+
+		# Example of type: MAGETABChecker
+		my $type = $pipeline->$daemon;
+		next TYPE unless defined($type);
+
+# Create a temp file to store pid,
+# suspect only stores pid of child processs as parent ones are written to database
+# Also this file seems to disappear once pid is written into database
+		my $pidfile =
+		  File::Temp::tempnam( $CONFIG->get_AUTOSUBMISSIONS_FILEBASE,
+			"$submis_type.$type" );
+
+		my $pid = fork();
+
+		# The child returns from the fork() with a
+		# value of 0 to signify that it is the child pseudo-process.
+		if ( $pid == 0 ) {
+
+			# child
+			# Spawn daemon
+			$PROGRAM_NAME .= ".$submis_type.$type";
+
+		   # Example of class: EBI::FGPT::AutoSubmission::Daemon::MAGETABChecker
+			my $daemon_class = "EBI::FGPT::AutoSubmission::Daemon::" . $type;
+
+            # Checking this is a valid class for which we have a module installed.
+			eval "use $daemon_class";
+			if ($@) {
+				die "Could not load $daemon_class. $!, $@";
+			}
+
+			my $threshold;
+			my $comma_and_space = qr(\s*,\s*);
+
+			foreach
+			  my $level ( split $comma_and_space, $pipeline->checker_threshold )
+			{
+				my $get_level = "get_$level";
+				if ($threshold) {
+					$threshold = ( $threshold | $CONFIG->$get_level );
+				}
+				else {
+					$threshold = $CONFIG->$get_level;
+				}
+			}
+
+		  # Common daemon atts, most values come from pipeline table of database
+			my %atts = (
+				polling_interval  => $pipeline->polling_interval,
+				experiment_type   => $submis_type,
+				checker_threshold => $threshold,
+				autosubs_admin    => $CONFIG->get_AUTOSUBS_ADMIN(),
+				accession_prefix  => $pipeline->accession_prefix,
+				pidfile           => $pidfile,
+				quit_when_done    => $stop,
+			);
+
+			# Exporter sepcific atts
+			if ( $daemon eq "exporter_daemon" ) {
+				$atts{pipeline_subdir}     = $pipeline->pipeline_subdir;
+				$atts{keep_protocol_accns} = $pipeline->keep_protocol_accns;
+			}
+
+			my $daemon_instance = $daemon_class->new( \%atts );
+			$daemon_instance->run;
+			exit(0);
+		}
+		elsif ($pid) {
+
+			# parent
+
+			# Sleep for a few secs to allow pid file to be written by child
+			sleep 5;
+
+			open( my $pid_fh, "<", $pidfile )
+			  or $log->log_and_die(
+				level   => 'alert',
+				message =>
+				  "Could not open temp pid file $pidfile for reading. $!" . "\n"
+			  );
+
+			my @pids = <$pid_fh>;
+			push( @child_pids, $pids[0] );
+
+			# Store pid in subs tracking
+			# ArrayExpress::AutoSubmission::DB::DaemonInstance->insert(
+			# 	{
+			# 		pipeline_id => $pipeline->id,
+			# 		daemon_type => $type,
+			# 		pid         => $pids[0],
+			# 		start_time  => date_now(),
+			# 		running     => 1,
+			# 		user        => getlogin,
+			# 	}
+			# );
+
+			unlink $pidfile;
+		}
+		else {
+			$log->log_and_die(
+				level   => 'alert',
+				message =>
+				  "Couldn't fork to create $submis_type $type daemon: $!" . "\n"
+			);
+		}
+	}
+}
+$log->info("Waiting for child processes...");
+
+# Monitor daemon processes
+my %dead;
+while (1) {
+	my @dead_pids = grep { ( kill 0, $_ ) == 0 } @child_pids;
+
+  PID: foreach my $pid (@dead_pids) {
+
+		# Skip if we've already handled this
+		chomp $pid;
+		next PID if $dead{$pid};
+		$log->info("$pid is dead");
+
+		# Record that the process has died
+
+		# my @results = ArrayExpress::AutoSubmission::DB::DaemonInstance->search(
+		# 	running => 1,
+		# 	pid     => $pid,
+		# );
+		#
+		# if ( my $di = $results[0] ) {
+		# 	$di->set( running => 0, end_time => date_now() );
+		# 	$di->update;
+		# }
+
+		$dead{$pid} = 1;
+	}
+
+	if ( scalar(@dead_pids) == scalar(@child_pids) ) {
+
+		# They are all dead - we can exit
+		exit;
+	}
+	sleep 2;
+}


### PR DESCRIPTION
This is stripped and modified copy of the launch_tracking_daemons.pl script. It allows for the use of the existing quit_when_done option in the MAGETABChecker Perl module. 

With this option activated, what happens is that it fetches all experiments currently waiting for checking, and runs them through the checker cycle. Once the script has run, it will wait for a defined time (currently set to 5 min) and then quit the child processes and not start a new loop. 

The use case for this is to be able to run the checker daemon script/functionality on the EBI cluster where we cannot have daemons running for prolonged time. This script can thus be used as part of a cron job to activate the checker daemon cycle periodically. 

I also removed the default tracking of the running daemon instances in the submissions tracking database. It is not helpful to track every run of the checker and create endless entries in the DB, e.g if we run every 10 min. 
